### PR TITLE
switch to MONTH view by default

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -6,6 +6,6 @@ layout: page
 {% include components/quarantine.md %}
 <br />
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=ZWw0MmM5Zjc1cjJyNHRmaGg1NTJ1YmdpNnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=ZGRtY2xncjBsdnFudGMwbXBncmJkOWQ0Ym9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23F09300&amp;color=%239E69AF&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;showTabs=1&amp;showPrint=1&amp;showTz=1&amp;mode=AGENDA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=ZWw0MmM5Zjc1cjJyNHRmaGg1NTJ1YmdpNnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=ZGRtY2xncjBsdnFudGMwbXBncmJkOWQ0Ym9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23F09300&amp;color=%239E69AF&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;showTabs=1&amp;showPrint=1&amp;showTz=1&amp;mode=MONTH" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
 {% include components/orthodox-calendar.html %}


### PR DESCRIPTION
Switch to MONTH view by default in order to prevent scrolling forward, unless calendar is switched to Agenda mode.

<img width="915" alt="Screen Shot 2022-05-25 at 10 22 52 PM" src="https://user-images.githubusercontent.com/2446/170402483-a078b0aa-94dd-4495-84b1-e601019ae07b.png">
